### PR TITLE
Remove invalid `dates` field from Zenodo metadata payload

### DIFF
--- a/upload_dump_zenodo/upload_dump_zenodo.py
+++ b/upload_dump_zenodo/upload_dump_zenodo.py
@@ -120,6 +120,8 @@ def update_metadata(version_url, release_data):
         metadata['version'] = release_data['filename'].split('-', 1)[0]
         metadata['description'] = format_description(release_data)
         metadata['related_identifiers'] = related_ids
+        if "dates" in metadata:
+            del metadata["dates"]
         updated_metadata = {'metadata': metadata}
         try:
             r = requests.put(version_url, params={'access_token': ZENODO_TOKEN}, data=json.dumps(updated_metadata), headers=HEADERS)
@@ -229,6 +231,7 @@ def check_release_data(release_data):
         if not total_present:
             print("Total orgs count not found in release notes")
         return False
+
 
 def get_previous_version_doi(parent_record_id):
     print("Getting DOI for previous version")


### PR DESCRIPTION
### Summary
This PR fixes metadata update failures when using the Zenodo `newversion` API by removing an invalid `dates` field automatically copied from previous versions. Closes https://github.com/ror-community/ror-roadmap/issues/312

### Background
- Zenodo rejects metadata containing:
  ```json
  "dates": [
    { "type": "created" }
  ]
because:

- `"type": "created"` is not valid (only Collected, Valid, Withdrawn are allowed).
- `start` or` end` date fields are required.
- The API call returned:
  ```json
   {
    "status": 400,
    "message": "A validation error occurred.",
    "errors": [
      { "field": "metadata.dates", "messages": ["Invalid date provided."] }
    ]
  }

https://developers.zenodo.org/?python#representation

### Change

Added a cleanup step:
  ```python
  if "dates" in metadata:
      del metadata["dates"]