### PR TITLE
Add error logging - Updating metadata

### DIFF
--- a/upload_dump_zenodo/upload_dump_zenodo.py
+++ b/upload_dump_zenodo/upload_dump_zenodo.py
@@ -127,12 +127,16 @@ def update_metadata(version_url, release_data):
             r = requests.put(version_url, params={'access_token': ZENODO_TOKEN}, data=json.dumps(updated_metadata), headers=HEADERS)
             r.raise_for_status()
             if r.status_code == 200:
-                "Metadata updated successfully"
+                print("Metadata updated successfully")
         except requests.exceptions.HTTPError as e:
+            print(f"HTTP Error: {e}")
+            print(f"Response body: {e.response.text}")
             raise SystemExit(e)
         except requests.exceptions.RequestException as e:
             raise SystemExit(e)
     except requests.exceptions.HTTPError as e:
+        print(f"HTTP Error: {e}")
+        print(f"Response body: {e.response.text}")
         raise SystemExit(e)
     except requests.exceptions.RequestException as e:
         raise SystemExit(e)


### PR DESCRIPTION
We have failing github action when updating metadata. This will log the error message and help better narrow down the issue and fix it.
https://github.com/ror-community/ror-records/actions/runs/23809833882/job/69393483131