### PR TITLE
Normalize invisible characters before org name to ROR ID lookup

### DIFF
--- a/create_relationships_from_github/create_relationships.py
+++ b/create_relationships_from_github/create_relationships.py
@@ -7,6 +7,7 @@ import time
 import asyncio
 import logging
 import argparse
+import unicodedata
 from dataclasses import dataclass
 import requests
 from github_project_issues import get_column_issues
@@ -73,6 +74,24 @@ def get_ror_name(ror_id, max_retries=3, retry_delay=5):
             return ""
 
 
+# U+200B ZERO WIDTH SPACE, U+200C/200D ZERO WIDTH (NON-)JOINER,
+# U+2060 WORD JOINER, U+FEFF ZERO WIDTH NO-BREAK SPACE
+ZERO_WIDTH_CHARS_RE = re.compile('[\u200b\u200c\u200d\u2060\ufeff]')
+
+
+def normalize_name(name):
+    """Remove invisible characters and normalize whitespace in an org name.
+
+    Names pasted into GitHub issues sometimes carry zero-width characters
+    (notably U+200B). str.strip() does not remove them, so an otherwise
+    identical name fails the exact-match lookup against the release CSV and
+    the record's ROR ID is silently written as an empty string.
+    """
+    name = ZERO_WIDTH_CHARS_RE.sub('', name)
+    name = unicodedata.normalize('NFKC', name)
+    return ' '.join(name.split())
+
+
 def find_between(s, first, last):
     try:
         start = s.index(first) + len(first)
@@ -98,7 +117,7 @@ def dict_from_csv(f):
             else:
                 name = get_ror_name(ror_id)
             ids_k_names_v[ror_id] = name
-            names_k_ids_v[name] = ror_id
+            names_k_ids_v[normalize_name(name)] = ror_id
     return release_ids, ids_k_names_v, names_k_ids_v
 
 
@@ -145,9 +164,13 @@ def extract_relationships(issues, input_file, output_file):
                 org_ror_id = find_between(issue_text, 'ROR ID:', '\n')
                 org_name = find_between(
                     issue_text, 'Name of organization:', '\n')
-                org_name = org_name.split('*')[0]
+                org_name = normalize_name(org_name.split('*')[0])
                 if not org_ror_id:
                     org_ror_id = names_k_ids_v.get(org_name, '')
+                    if not org_ror_id:
+                        logger.warning(
+                            f"Issue {issue_number}: no ROR ID found for "
+                            f"'{org_name}'. Record ID will be empty.")
                 for relationship in relationships:
                     relationship = relationship.split(' ')
                     relationship = [r.strip() for r in relationship if r != '']

--- a/create_relationships_from_github/test_create_relationships.py
+++ b/create_relationships_from_github/test_create_relationships.py
@@ -126,3 +126,44 @@ def test_cross_issue_cycle(tmp_path):
     flagged = [r for r in rows if (_field(r, 'record_id'), _field(r, 'related_id')) in ab_pairs]
     assert len(flagged) == 4
     assert all(_field(r, 'rel_type') == 'Error' for r in flagged)
+
+
+ZERO_WIDTH_SPACE = '\u200b'
+
+
+def test_name_with_zero_width_char_still_resolves_ror_id(tmp_path):
+    """A new record's name carrying an invisible character must still match.
+
+    Names pasted into GitHub issues sometimes carry a zero-width space. When
+    the issue has no ROR ID yet (a new record), the ID is looked up by name;
+    an unmatched name silently yields an empty Record ID.
+    """
+    input_csv = tmp_path / 'input.csv'
+    output_csv = tmp_path / 'output.csv'
+    _write_input_csv(input_csv, [(ID_A, 'Org A*en'), (ID_B, 'Org B*en')])
+
+    issue = _issue(101, '', ZERO_WIDTH_SPACE + 'Org A', [(ID_B, 'parent')])
+
+    extract_relationships([issue], str(input_csv), str(output_csv))
+    rows = _read_output_rows(str(output_csv))
+
+    forward = [r for r in rows if _field(r, 'related_id') == ID_B]
+    assert forward, 'expected a row relating the new record to ID_B'
+    assert _field(forward[0], 'record_id') == ID_A
+
+    inverse = [r for r in rows if _field(r, 'record_id') == ID_B]
+    assert inverse, 'expected the inverse row'
+    assert _field(inverse[0], 'related_id') == ID_A
+
+
+def test_zero_width_char_not_written_to_output(tmp_path):
+    input_csv = tmp_path / 'input.csv'
+    output_csv = tmp_path / 'output.csv'
+    _write_input_csv(input_csv, [(ID_A, 'Org A*en'), (ID_B, 'Org B*en')])
+
+    issue = _issue(101, '', ZERO_WIDTH_SPACE + 'Org A', [(ID_B, 'parent')])
+
+    extract_relationships([issue], str(input_csv), str(output_csv))
+
+    with open(output_csv, encoding='utf-8') as f:
+        assert ZERO_WIDTH_SPACE not in f.read()


### PR DESCRIPTION
## Problem

Names pasted into GitHub issues sometimes carry a zero-width space (U+200B). When an issue has no ROR ID yet — the case for a new record — `create_relationships.py` resolves the ID by exact-match name lookup against the release CSV:

```python
org_ror_id = names_k_ids_v.get(org_name, '')
```

`str.strip()` does not remove zero-width characters (`'​'.isspace()` is `False`), so the lookup misses and the Record ID is silently written as `''`.

Downstream, `generate_relationships.py` calls `get_record_status(check_related_id, version)` at line 272 — one line *before* its own `if (check_record_id and check_related_id)` guard at line 273 — so the empty ID becomes a hard crash:

```
TypeError: unsupported operand type(s) for +: 'NoneType' and 'str'
```

This took down the rc-v2.10 relationships job on issue #36066, whose record had been assigned `005f34p76` all along. It recurred on regeneration, since nothing upstream had changed.

## Fix

Add `normalize_name()` — removes zero-width characters, applies NFKC normalization, collapses whitespace — and apply it to **both** sides of the lookup so keys and query normalize identically.

Also log a warning when a name fails to resolve. Previously an unresolved name produced an empty column and no signal; the failure only surfaced later as a `TypeError` in a different script.

## Verification

Two tests added, both confirmed failing before the fix (`assert '' == 'https://ror.org/028rfb880'`) and passing after. Full suite: 7 passed.
